### PR TITLE
Add response `content` for `/chat/badges/global`

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1450,6 +1450,36 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        set_id:
+                          type: string
+                          example: vip
+                        versions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                example: "1"
+                              image_url_1x:
+                                type: string
+                                example: https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/1
+                              image_url_2x:
+                                type: string
+                                example: https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/2
+                              image_url_4x:
+                                type: string
+                                example: https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/3
         "401":
           description: "Unauthenticated: Missing/invalid Token"
         "404":


### PR DESCRIPTION
Hi!

I've been using this spec in my project (thanks a lot for the huge work you've been doing!!) and saw a spot where I could contribute a bit to it. I just added the same structure as for `/chat/badges/` and changed the example to that on Twitch's docs.

Cheers!